### PR TITLE
Clear claim mapping JwtSecurityTokenHandler

### DIFF
--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using LeaderboardBackend.Services;
+using System.IdentityModel.Tokens.Jwt;
+
+JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
 // FIXME: temp
 const string DbName = "Leaderboard";

--- a/LeaderboardBackend/Services/UserService.cs
+++ b/LeaderboardBackend/Services/UserService.cs
@@ -1,3 +1,4 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using LeaderboardBackend.Models;
 using Microsoft.EntityFrameworkCore;
@@ -28,7 +29,7 @@ namespace LeaderboardBackend.Services
 
 		public async Task<User?> GetUserFromClaims(ClaimsPrincipal claims)
 		{
-			if (!claims.HasClaim(c => c.Type == "Email"))
+			if (!claims.HasClaim(c => c.Type == JwtRegisteredClaimNames.Email))
 			{
 				return null;
 			}


### PR DESCRIPTION
Closes #15 

Why would a system designed to work with JWTs use a claim mapping that automatically renames things to xmlsoap claim names? Your guess is as good as mine.