### PR TITLE
MVP: Create Category Controller

### DIFF
--- a/LeaderboardBackend.Integration/Categories.cs
+++ b/LeaderboardBackend.Integration/Categories.cs
@@ -1,0 +1,58 @@
+using LeaderboardBackend.Models.Entities;
+using LeaderboardBackend.Models.Requests.Categories;
+using NUnit.Framework;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LeaderboardBackend.Integration;
+
+[TestFixture]
+internal class Categories
+{
+	private static TestApiFactory Factory = null!;
+	private static HttpClient ApiClient = null!;
+	private static JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+	};
+
+	[SetUp]
+	public static void SetUp()
+	{
+		Factory = new TestApiFactory();
+		ApiClient = Factory.CreateClient();
+	}
+
+	[Test]
+	public static async Task GetCategory_NoCategories()
+	{
+		long id = 1;
+		HttpResponseMessage response = await ApiClient.GetAsync($"/api/categories/{id}");
+		Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Test]
+	public static async Task CreateCategory_GetCategory()
+	{
+		CreateCategoryRequest createBody = new()
+		{
+			Name = Generators.GenerateRandomString(),
+			Slug = Generators.GenerateRandomString(),
+			LeaderboardId = 1
+		};
+		HttpResponseMessage createResponse = await ApiClient.PostAsJsonAsync("/api/categories", createBody, JsonSerializerOptions);
+		createResponse.EnsureSuccessStatusCode();
+		Category createdCategory = await HttpHelpers.ReadFromResponseBody<Category>(createResponse, JsonSerializerOptions);
+
+		Assert.AreEqual(1, createdCategory.PlayersMax);
+
+		HttpResponseMessage getResponse = await ApiClient.GetAsync($"/api/categories/{createdCategory?.Id}");
+		getResponse.EnsureSuccessStatusCode();
+		Category retrievedCategory = await HttpHelpers.ReadFromResponseBody<Category>(getResponse, JsonSerializerOptions);
+
+		Assert.AreEqual(createdCategory, retrievedCategory);
+	}
+}

--- a/LeaderboardBackend.Test/Controllers/CategoriesControllerTest.cs
+++ b/LeaderboardBackend.Test/Controllers/CategoriesControllerTest.cs
@@ -1,0 +1,54 @@
+
+using NUnit.Framework;
+using Moq;
+using LeaderboardBackend.Controllers;
+using LeaderboardBackend.Services;
+using LeaderboardBackend.Models;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LeaderboardBackend.Test.Controllers;
+
+public class CategoryTests
+{
+	private Mock<ICategoryService> _categoryServiceMock = null!;
+
+	private CategoriesController _controller = null!;
+
+	[SetUp]
+	public void Setup()
+	{
+		_categoryServiceMock = new Mock<ICategoryService>();
+
+		_controller = new CategoriesController(
+			_categoryServiceMock.Object
+		);
+	}
+
+	[Test]
+	public async Task GetCategory_NotFound_CategoryDoesNotExist()
+	{
+		_categoryServiceMock
+			.Setup(x => x.GetCategory(It.IsAny<ulong>()))
+			.Returns(Task.FromResult<Category?>(null));
+
+		ActionResult<Category> response = await _controller.GetCategory((ulong)1);
+
+		NotFoundResult? actual = response.Result as NotFoundResult;
+		Assert.NotNull(actual);
+		Assert.AreEqual(404, actual!.StatusCode);
+	}
+
+	[Test]
+	public async Task GetCategory_Ok_CategoryExists()
+	{
+		_categoryServiceMock
+			.Setup(x => x.GetCategory(It.IsAny<ulong>()))
+			.Returns(Task.FromResult<Category?>(new Category { Id = 1 }));
+
+		ActionResult<Category> response = await _controller.GetCategory((ulong)1);
+
+		Assert.NotNull(response.Value);
+		Assert.AreEqual(1, response.Value?.Id);
+	}
+}

--- a/LeaderboardBackend.Test/Controllers/CategoriesControllerTest.cs
+++ b/LeaderboardBackend.Test/Controllers/CategoriesControllerTest.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using Moq;
 using LeaderboardBackend.Controllers;
 using LeaderboardBackend.Services;
-using LeaderboardBackend.Models;
+using LeaderboardBackend.Models.Entities;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
@@ -29,10 +29,10 @@ public class CategoryTests
 	public async Task GetCategory_NotFound_CategoryDoesNotExist()
 	{
 		_categoryServiceMock
-			.Setup(x => x.GetCategory(It.IsAny<ulong>()))
+			.Setup(x => x.GetCategory(It.IsAny<long>()))
 			.Returns(Task.FromResult<Category?>(null));
 
-		ActionResult<Category> response = await _controller.GetCategory((ulong)1);
+		ActionResult<Category> response = await _controller.GetCategory((long)1);
 
 		NotFoundResult? actual = response.Result as NotFoundResult;
 		Assert.NotNull(actual);
@@ -43,10 +43,10 @@ public class CategoryTests
 	public async Task GetCategory_Ok_CategoryExists()
 	{
 		_categoryServiceMock
-			.Setup(x => x.GetCategory(It.IsAny<ulong>()))
+			.Setup(x => x.GetCategory(It.IsAny<long>()))
 			.Returns(Task.FromResult<Category?>(new Category { Id = 1 }));
 
-		ActionResult<Category> response = await _controller.GetCategory((ulong)1);
+		ActionResult<Category> response = await _controller.GetCategory((long)1);
 
 		Assert.NotNull(response.Value);
 		Assert.AreEqual(1, response.Value?.Id);

--- a/LeaderboardBackend.Test/Services/CategoryServiceTests.cs
+++ b/LeaderboardBackend.Test/Services/CategoryServiceTests.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 using LeaderboardBackend.Services;
-using LeaderboardBackend.Models;
-using Microsoft.EntityFrameworkCore;
+using LeaderboardBackend.Test.Helpers;
 using System.Threading.Tasks;
 
 namespace LeaderboardBackend.Test.Services;
@@ -13,22 +12,26 @@ public class CategoryServiceTests
 	[SetUp]
 	public void Setup()
 	{
-		_service = new CategoryService(
-			new ApplicationContext(
-				new DbContextOptionsBuilder<ApplicationContext>().UseNpgsql(
-					"Host=localhost;Port=5433;Database=leaderboardstest;Username=admin;Password=example;"
-				).Options
-			)
-		);
+		_service = new CategoryService(ApplicationContextFactory.CreateNewContext());
 	}
 
 	[Test]
 	public async Task GetCategory_GetsAnExistingCategory()
 	{
+		await _service.CreateCategory(new() {
+			LeaderboardId = 1,
+			Name = "Test",
+			Slug = "test",
+			PlayersMax = 1,
+			PlayersMin = 1
+		});
+
 		var result = await _service.GetCategory(1);
 
 		Assert.NotNull(result);
 		Assert.AreEqual(1, result?.Id);
+		Assert.AreEqual(1, result?.PlayersMax);
+		Assert.AreEqual(1, result?.PlayersMin);
 	}
 
 	[Test]

--- a/LeaderboardBackend.Test/Services/CategoryServiceTests.cs
+++ b/LeaderboardBackend.Test/Services/CategoryServiceTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using LeaderboardBackend.Services;
+using LeaderboardBackend.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+
+namespace LeaderboardBackend.Test.Services;
+
+public class CategoryServiceTests
+{
+	private static CategoryService _service = null!;
+
+	[SetUp]
+	public void Setup()
+	{
+		_service = new CategoryService(
+			new ApplicationContext(
+				new DbContextOptionsBuilder<ApplicationContext>().UseNpgsql(
+					"Host=localhost;Port=5433;Database=leaderboardstest;Username=admin;Password=example;"
+				).Options
+			)
+		);
+	}
+
+	[Test]
+	public async Task GetCategory_GetsAnExistingCategory()
+	{
+		var result = await _service.GetCategory(1);
+
+		Assert.NotNull(result);
+		Assert.AreEqual(1, result?.Id);
+	}
+
+	[Test]
+	public async Task GetCategory_ReturnsNullForNonExistingID()
+	{
+		var result = await _service.GetCategory(0);
+
+		Assert.Null(result);
+	}
+}

--- a/LeaderboardBackend/Controllers/Annotations/Conventions.cs
+++ b/LeaderboardBackend/Controllers/Annotations/Conventions.cs
@@ -15,6 +15,7 @@ public static class Conventions
 	{ }
 
 	[ProducesResponseType(StatusCodes.Status201Created)]
+	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	public static void Post(params object[] parameters)
 	{ }

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using LeaderboardBackend.Models;
+using LeaderboardBackend.Services;
+
+namespace LeaderboardBackend.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Produces("application/json")]
+public class CategoriesController : ControllerBase
+{
+	private readonly ICategoryService _categoryService;
+
+	public CategoriesController(
+		ICategoryService categoryService
+	)
+	{
+		_categoryService = categoryService;
+	}
+
+	/// <summary>Gets a Category from its ID.</summary>
+	/// <response code="200">The Category with the provided ID.</response>
+	/// <response code="404">If no Category can be found.</response>
+	[HttpGet("{id}")]
+	public async Task<ActionResult<Category>> GetCategory(ulong id)
+	{
+		Category? category = await _categoryService.GetCategory(id);
+		if (category == null)
+		{
+			return NotFound();
+		}
+
+		return category;
+	}
+}

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -41,6 +41,7 @@ public class CategoriesController : ControllerBase
 	/// <summary>Creates a new Category. Mod-only.</summary>
 	/// <param name="body">A CreateCategoryRequest instance.</param>
 	/// <response code="201">The created Category.</response>
+	/// <response code="400">If the request is malformed.</response>
 	/// <response code="404">If a non-mod calls this.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Post))]

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
-using LeaderboardBackend.Models;
+using LeaderboardBackend.Controllers.Annotations;
+using LeaderboardBackend.Models.Entities;
+using LeaderboardBackend.Models.Requests.Categories;
 using LeaderboardBackend.Services;
 
 namespace LeaderboardBackend.Controllers;
@@ -21,8 +23,10 @@ public class CategoriesController : ControllerBase
 	/// <summary>Gets a Category from its ID.</summary>
 	/// <response code="200">The Category with the provided ID.</response>
 	/// <response code="404">If no Category can be found.</response>
+	[ApiConventionMethod(typeof(Conventions),
+						 nameof(Conventions.Get))]
 	[HttpGet("{id}")]
-	public async Task<ActionResult<Category>> GetCategory(ulong id)
+	public async Task<ActionResult<Category>> GetCategory(long id)
 	{
 		Category? category = await _categoryService.GetCategory(id);
 		if (category == null)
@@ -31,5 +35,29 @@ public class CategoriesController : ControllerBase
 		}
 
 		return category;
+	}
+
+	// FIXME: Allow only mods to call this
+	/// <summary>Creates a new Category. Mod-only.</summary>
+	/// <param name="body">A CreateCategoryRequest instance.</param>
+	/// <response code="201">The created Category.</response>
+	/// <response code="404">If a non-mod calls this.</response>
+	[ApiConventionMethod(typeof(Conventions),
+						 nameof(Conventions.Post))]
+	[HttpPost]
+	public async Task<ActionResult<Category>> CreateCategory([FromBody] CreateCategoryRequest body)
+	{
+		Category category = new()
+		{
+			Name = body.Name,
+			Slug = body.Slug,
+			Rules = body.Rules,
+			PlayersMin = body.PlayersMin ?? 1,
+			PlayersMax = body.PlayersMax ?? body.PlayersMin ?? 1,
+			LeaderboardId = body.LeaderboardId,
+		};
+
+		await _categoryService.CreateCategory(category);
+		return CreatedAtAction(nameof(GetCategory), new { id = category.Id }, category);
 	}
 }

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -34,7 +34,7 @@ public class CategoriesController : ControllerBase
 			return NotFound();
 		}
 
-		return category;
+		return Ok(category);
 	}
 
 	// FIXME: Allow only mods to call this

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -49,6 +49,7 @@ public class LeaderboardsController : ControllerBase
 	/// <summary>Creates a new Leaderboard. Admin-only.</summary>
 	/// <param name="body">A CreateLeaderboardRequest instance.</param>
 	/// <response code="201">The created Leaderboard.</response>
+	/// <response code="400">If the request is malformed.</response>
 	/// <response code="404">If a non-admin calls this.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Post))]

--- a/LeaderboardBackend/Controllers/UsersController.cs
+++ b/LeaderboardBackend/Controllers/UsersController.cs
@@ -43,7 +43,7 @@ public class UsersController : ControllerBase
 	/// <summary>Registers a new user.</summary>
 	/// <param name="body">A RegisterRequest instance.</param>
 	/// <response code="201">The created User object.</response>
-	/// <response code="400">If the passwords don't match.</response>
+	/// <response code="400">If the passwords don't match, or if the request is otherwise malformed.</response>
 	/// <response code="409">If login details can't be found.</response>
 	[ProducesResponseType(StatusCodes.Status201Created)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -86,9 +86,11 @@ public class UsersController : ControllerBase
 	/// <summary>Logs a new user in.</summary>
 	/// <param name="body">A LoginRequest instance.</param>
 	/// <response code="200">A <code>LoginResponse</code> object.</response>
+	/// <response code="400">If the request is malformed.</response>
 	/// <response code="401">If the wrong details were passed.</response>
 	/// <response code="404">If a User can't be found.</response>
 	[ProducesResponseType(StatusCodes.Status200OK)]
+	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
 	[AllowAnonymous]

--- a/LeaderboardBackend/Models/Annotations/PlayersMaxAttribute.cs
+++ b/LeaderboardBackend/Models/Annotations/PlayersMaxAttribute.cs
@@ -1,0 +1,29 @@
+using LeaderboardBackend.Models.Requests.Categories;
+using System.ComponentModel.DataAnnotations;
+
+namespace LeaderboardBackend.Models.Annotations;
+
+public class PlayersMaxAttribute : ValidationAttribute
+{
+	public string GetErrorMessage(List<string> errors) =>
+		$"Your password has the following errors: {string.Join("; ", errors)}";
+
+	protected override ValidationResult? IsValid(object? _, ValidationContext context)
+	{
+		CreateCategoryRequest request = (CreateCategoryRequest)context.ObjectInstance;
+
+		if (request.PlayersMax is null)
+		{
+			return ValidationResult.Success;
+		}
+
+		if (request.PlayersMax < request.PlayersMin)
+		{
+			return new ValidationResult(
+				$"playersMax ({request.PlayersMax}) must be at least equal to playersMin ({request.PlayersMin})."
+			);
+		}
+
+		return ValidationResult.Success;
+	}
+}

--- a/LeaderboardBackend/Models/Annotations/PlayersMaxAttribute.cs
+++ b/LeaderboardBackend/Models/Annotations/PlayersMaxAttribute.cs
@@ -5,9 +5,6 @@ namespace LeaderboardBackend.Models.Annotations;
 
 public class PlayersMaxAttribute : ValidationAttribute
 {
-	public string GetErrorMessage(List<string> errors) =>
-		$"Your password has the following errors: {string.Join("; ", errors)}";
-
 	protected override ValidationResult? IsValid(object? _, ValidationContext context)
 	{
 		CreateCategoryRequest request = (CreateCategoryRequest)context.ObjectInstance;

--- a/LeaderboardBackend/Models/Entities/Category.cs
+++ b/LeaderboardBackend/Models/Entities/Category.cs
@@ -3,27 +3,59 @@ using System.Text.Json.Serialization;
 
 namespace LeaderboardBackend.Models.Entities;
 
+/// <summary>A Category tied to a Leaderboard.</summary>
 public class Category
 {
+	/// <summary>The Category's ID. Generated on creation.</summary>
 	public long Id { get; set; }
 
-	[Required] 
+	/// <summary>The Category's name.</summary>
+	/// <example>Mongolian Throat Singing%</example>
+	[Required]
 	public string Name { get; set; } = null!;
 
-	[Required] 
+	/// <summary>
+	/// The Category's slug. <br/>
+	/// Must be 2-25 characters inclusive and only consist of letters, numbers, and
+	/// hyphens.
+	/// </summary>
+	/// <example>mongolian-throat-singing</example>
+	[Required]
 	public string Slug { get; set; } = null!;
-	
+
+	/// <summary>Category-specific rules.</summary>
 	public string? Rules { get; set; }
 
-	[Required] 
+	/// <summary>Minimum player count for this Category. Defaults to 1.</summary>
+	[Required]
 	public int PlayersMin { get; set; }
 
-	[Required] 
+	/// <summary>
+	/// Maximum player count for this Category. Defaults to PlayersMin.
+	/// </summary>
+	[Required]
 	public int PlayersMax { get; set; }
 
-	[Required] 
+	/// <summary>ID of the Leaderboard this Category belongs to.</summary>
+	[Required]
 	public long LeaderboardId { get; set; }
 
-	[JsonIgnore] 
+	[JsonIgnore]
 	public Leaderboard? Leaderboard { get; set; }
+
+	public override bool Equals(object? obj)
+	{
+		return obj is Category category &&
+			   Id == category.Id &&
+			   Name == category.Name &&
+			   Slug == category.Slug &&
+			   PlayersMax == category.PlayersMax &&
+			   PlayersMin == category.PlayersMin &&
+			   LeaderboardId == category.LeaderboardId;
+	}
+
+	public override int GetHashCode()
+	{
+		return HashCode.Combine(Id, Name, Slug, LeaderboardId);
+	}
 }

--- a/LeaderboardBackend/Models/Requests/Categories/Create.cs
+++ b/LeaderboardBackend/Models/Requests/Categories/Create.cs
@@ -1,3 +1,4 @@
+using LeaderboardBackend.Models.Annotations;
 using System.ComponentModel.DataAnnotations;
 
 namespace LeaderboardBackend.Models.Requests.Categories;
@@ -24,11 +25,14 @@ public record CreateCategoryRequest
 	public string? Rules { get; set; }
 
 	/// <summary>Minimum player count for this Category. Defaults to 1.</summary>
+	[Range(1, int.MaxValue)]
 	public int? PlayersMin { get; set; }
 
 	/// <summary>
 	/// Maximum player count for this Category. Defaults to PlayersMin.
 	/// </summary>
+	[Range(1, int.MaxValue)]
+	[PlayersMax]
 	public int? PlayersMax { get; set; }
 
 	/// <summary>ID of the Leaderboard this Category belongs to.</summary>

--- a/LeaderboardBackend/Models/Requests/Categories/Create.cs
+++ b/LeaderboardBackend/Models/Requests/Categories/Create.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LeaderboardBackend.Models.Requests.Categories;
+
+/// <summary>Request object sent when creating a Category.</summary>
+public record CreateCategoryRequest
+{
+	/// <summary>Name for the new Category.</summary>
+	/// <example>Mongolian Throat Singing%</example>
+	[Required]
+	public string Name { get; set; } = null!;
+
+	/// <summary>
+	/// The bit in the URL that uniquely identifies this Category. <br/>
+	/// E.g.: https://leaderboards.gg/slug-for-board/slug-for-category <br/>
+	/// Must be 2-25 characters inclusive and only consist of letters, numbers, and
+	/// hyphens.
+	/// </summary>
+	/// <example>mongolian-throat-singing</example>
+	[Required]
+	public string Slug { get; set; } = null!;
+
+	/// <summary>Category-specific rules.</summary>
+	public string? Rules { get; set; }
+
+	/// <summary>Minimum player count for this Category. Defaults to 1.</summary>
+	public int? PlayersMin { get; set; }
+
+	/// <summary>
+	/// Maximum player count for this Category. Defaults to PlayersMin.
+	/// </summary>
+	public int? PlayersMax { get; set; }
+
+	/// <summary>ID of the Leaderboard this Category belongs to.</summary>
+	[Required]
+	public long LeaderboardId { get; set; }
+}

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -30,6 +30,7 @@ ConfigureDbContext<ApplicationContext>(builder, useInMemoryDb);
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ILeaderboardService, LeaderboardService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<ICategoryService, CategoryService>();
 
 // Add controllers to the container.
 builder.Services.AddControllers(opt =>

--- a/LeaderboardBackend/Services/CategoryService.cs
+++ b/LeaderboardBackend/Services/CategoryService.cs
@@ -1,0 +1,18 @@
+using LeaderboardBackend.Models;
+
+namespace LeaderboardBackend.Services
+{
+	public class CategoryService : ICategoryService
+	{
+		private ApplicationContext _applicationContext;
+		public CategoryService(ApplicationContext applicationContext)
+		{
+			_applicationContext = applicationContext;
+		}
+
+		public async Task<Category?> GetCategory(ulong id)
+		{
+			return await _applicationContext.Categories.FindAsync(id);
+		}
+	}
+}

--- a/LeaderboardBackend/Services/CategoryService.cs
+++ b/LeaderboardBackend/Services/CategoryService.cs
@@ -1,4 +1,4 @@
-using LeaderboardBackend.Models;
+using LeaderboardBackend.Models.Entities;
 
 namespace LeaderboardBackend.Services
 {
@@ -10,9 +10,15 @@ namespace LeaderboardBackend.Services
 			_applicationContext = applicationContext;
 		}
 
-		public async Task<Category?> GetCategory(ulong id)
+		public async Task<Category?> GetCategory(long id)
 		{
 			return await _applicationContext.Categories.FindAsync(id);
+		}
+
+		public async Task CreateCategory(Category category)
+		{
+			_applicationContext.Categories.Add(category);
+			await _applicationContext.SaveChangesAsync();
 		}
 	}
 }

--- a/LeaderboardBackend/Services/ICategoryService.cs
+++ b/LeaderboardBackend/Services/ICategoryService.cs
@@ -1,9 +1,10 @@
-using LeaderboardBackend.Models;
+using LeaderboardBackend.Models.Entities;
 
 namespace LeaderboardBackend.Services
 {
 	public interface ICategoryService
 	{
-		Task<Category?> GetCategory(ulong id);
+		Task<Category?> GetCategory(long id);
+		Task CreateCategory(Category category);
 	}
 }

--- a/LeaderboardBackend/Services/ICategoryService.cs
+++ b/LeaderboardBackend/Services/ICategoryService.cs
@@ -1,0 +1,9 @@
+using LeaderboardBackend.Models;
+
+namespace LeaderboardBackend.Services
+{
+	public interface ICategoryService
+	{
+		Task<Category?> GetCategory(ulong id);
+	}
+}


### PR DESCRIPTION
Closes: #33. Based from: #34 

This creates the controller (and service) for Categories, plus one interaction from the MVP:

- An API client can get a category's fields by ID.

Future CategoriesController PRs will be based off of this