### PR TITLE
Allow Absence of Rules on POST Leaderboards

### DIFF
--- a/LeaderboardBackend/Controllers/Requests/Leaderboards/Create.cs
+++ b/LeaderboardBackend/Controllers/Requests/Leaderboards/Create.cs
@@ -2,6 +2,7 @@ namespace LeaderboardBackend.Controllers.Requests;
 
 public record CreateLeaderboardRequest
 {
-	public string Name { get; set; } = null!;
-	public string Slug { get; set; } = null!;
+	[Required] public string Name { get; set; } = null!;
+	[Required] public string Slug { get; set; } = null!;
+	public string? Rules { get; set; }
 }

--- a/LeaderboardBackend/Models/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Leaderboard.cs
@@ -7,5 +7,5 @@ public class Leaderboard
 	public ulong Id { get; set; }
 	[Required] public string Name { get; set; } = null!;
 	[Required] public string Slug { get; set; } = null!;
-	public string Rules { get; set; } = null!;
+	public string? Rules { get; set; }
 }


### PR DESCRIPTION
At some point, the `Leaderboard` model required `Rules` be passed on instantiation. This PR removes that requirement, as we shouldn't have to pass rules in when creating a leaderboard.