### PR TITLE
Don't overwrite existing env vars

### DIFF
--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -17,8 +17,9 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 DotEnv.Load(options: new DotEnvOptions(
 	ignoreExceptions: false,
+	overwriteExistingVars: false,
 	envFilePaths: new[] { builder.Configuration["EnvPath"] },
-	trimValues: true // Trims whitespace from values
+	trimValues: true
 ));
 
 // Configure database context


### PR DESCRIPTION
This will be useful for CI because we can pass stuff into the command
that actually runs tests rather than needing to mess with a .env file in
the CI script.