### PR TITLE
Pin PG Version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             POSTGRES_PASSWORD: ${ApplicationContext__PG__PASSWORD}
             POSTGRES_DB: ${ApplicationContext__PG__DB}
         volumes:
-            - 'db_data:/var/lib/postgresql/data'
+            - 'db_data:/var/lib/postgresql'
         ports:
             - ${ApplicationContext__PG__PORT}:5432
 


### PR DESCRIPTION
This PR pins postgres to one specific version, avoiding unexpected issues when accidentally upgrading. The docker compose file is also modernized. See [this issue](https://github.com/docker-library/postgres/issues/37) for potential problems with existing data.