### PR TITLE
#360 Include Rank in Get Run Response

### DIFF
--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -430,15 +430,6 @@ namespace LeaderboardBackend.Test
             );
 
             retrieved.Should().BeEquivalentTo(created);
-            retrieved.Should().BeEquivalentTo(
-                new
-                {
-                    PlayedOn = LocalDate.FromDateTime(new(2025, 1, 1)),
-                    Info = "",
-                    Time = Duration.FromMilliseconds(622111),
-                    User = UserViewModel.MapFrom(user)
-                }
-            );
         }
 
         [Test]

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -56,7 +56,7 @@ namespace LeaderboardBackend.Test
             };
 
             Category[] categories = [
-                new ()
+                new()
                 {
                     Name = "120 Stars",
                     Slug = "120_stars",
@@ -65,7 +65,7 @@ namespace LeaderboardBackend.Test
                     Type = RunType.Time,
                     Leaderboard = board,
                 },
-                new ()
+                new()
                 {
                     Name = "Min Stars",
                     Slug = "min_stars",
@@ -91,7 +91,7 @@ namespace LeaderboardBackend.Test
             IServiceScope scope = _factory.Services.CreateScope();
             ApplicationContext context = scope.ServiceProvider.GetRequiredService<ApplicationContext>();
 
-            Run run = new()
+            Run pb = new()
             {
                 CategoryId = _categoryIds[0],
                 Info = "",
@@ -100,18 +100,50 @@ namespace LeaderboardBackend.Test
                 UserId = TestInitCommonFields.Admin.Id,
             };
 
-            context.Add(run);
+            Run second = new()
+            {
+                CategoryId = _categoryIds[0],
+                Info = "",
+                PlayedOn = LocalDate.FromDateTime(new()),
+                TimeOrScore = Duration.FromSeconds(490).ToInt64Nanoseconds(),
+                UserId = TestInitCommonFields.Admin.Id,
+            };
+
+            context.AddRange(pb, second);
             await context.SaveChangesAsync();
             // Needed for resolving the run type for viewmodel mapping
-            await context.Entry(run).Reference(r => r.Category).LoadAsync();
-            await context.Entry(run).Reference(r => r.User).LoadAsync();
+            await context.Entry(pb).Reference(r => r.Category).LoadAsync();
+            await context.Entry(pb).Reference(r => r.User).LoadAsync();
+            await context.Entry(second).Reference(r => r.Category).LoadAsync();
+            await context.Entry(second).Reference(r => r.User).LoadAsync();
 
-            TimedRunViewModel retrieved = await _apiClient.Get<TimedRunViewModel>(
-                $"/api/runs/{run.Id.ToUrlSafeBase64String()}",
+            TimedRunViewModel retrievedPb = await _apiClient.Get<TimedRunViewModel>(
+                $"/api/runs/{pb.Id.ToUrlSafeBase64String()}",
                 new() { }
             );
 
-            retrieved.Should().BeEquivalentTo(RunViewModel.MapFrom(run));
+            RankedRun expectedRetrievedPb = new()
+            {
+                Count = 2,
+                Rank = 1,
+                Run = pb,
+            };
+
+            retrievedPb.Should().BeEquivalentTo(RunViewModel.MapFrom(expectedRetrievedPb));
+
+            TimedRunViewModel retrievedSecond = await _apiClient.Get<TimedRunViewModel>(
+                $"/api/runs/{second.Id.ToUrlSafeBase64String()}",
+                new() { }
+            );
+
+            RankedRun expectedRetrievedSecond = new()
+            {
+                Count = 0,
+                Rank = 0,
+                Run = second,
+            };
+
+            retrievedSecond.Should().BeEquivalentTo(RunViewModel.MapFrom(expectedRetrievedSecond));
         }
 
         [TestCase("1")]

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -58,7 +58,7 @@ namespace LeaderboardBackend.Test
             };
 
             Category[] categories = [
-                new ()
+                new()
                 {
                     Name = "120 Stars",
                     Slug = "120_stars",
@@ -67,7 +67,7 @@ namespace LeaderboardBackend.Test
                     Type = RunType.Time,
                     Leaderboard = board,
                 },
-                new ()
+                new()
                 {
                     Name = "Min Stars",
                     Slug = "min_stars",
@@ -100,7 +100,7 @@ namespace LeaderboardBackend.Test
             IServiceScope scope = _factory.Services.CreateScope();
             ApplicationContext context = scope.ServiceProvider.GetRequiredService<ApplicationContext>();
 
-            Run run = new()
+            Run pb = new()
             {
                 CategoryId = _categoryIds[0],
                 Info = "",
@@ -109,16 +109,50 @@ namespace LeaderboardBackend.Test
                 UserId = TestInitCommonFields.Admin.Id,
             };
 
-            context.Add(run);
+            Run second = new()
+            {
+                CategoryId = _categoryIds[0],
+                Info = "",
+                PlayedOn = LocalDate.FromDateTime(new()),
+                TimeOrScore = Duration.FromSeconds(490).ToInt64Nanoseconds(),
+                UserId = TestInitCommonFields.Admin.Id,
+            };
+
+            context.AddRange(pb, second);
             await context.SaveChangesAsync();
             // Needed for resolving the run type for viewmodel mapping
-            await context.Entry(run).Reference(r => r.Category).LoadAsync();
-            await context.Entry(run).Reference(r => r.User).LoadAsync();
+            await context.Entry(pb).Reference(r => r.Category).LoadAsync();
+            await context.Entry(pb).Reference(r => r.User).LoadAsync();
+            await context.Entry(second).Reference(r => r.Category).LoadAsync();
+            await context.Entry(second).Reference(r => r.User).LoadAsync();
 
-            HttpResponseMessage response = await _apiClient.GetRun(run.Id);
-            response.Should().Be200Ok().And.BeAs(
-                (TimedRunViewModel)RunViewModel.MapFrom(run)
+            TimedRunViewModel retrievedPb = await _apiClient.Get<TimedRunViewModel>(
+                $"/api/runs/{pb.Id.ToUrlSafeBase64String()}",
+                new() { }
             );
+
+            RankedRun expectedRetrievedPb = new()
+            {
+                Count = 2,
+                Rank = 1,
+                Run = pb,
+            };
+
+            retrievedPb.Should().BeEquivalentTo(RunViewModel.MapFrom(expectedRetrievedPb));
+
+            TimedRunViewModel retrievedSecond = await _apiClient.Get<TimedRunViewModel>(
+                $"/api/runs/{second.Id.ToUrlSafeBase64String()}",
+                new() { }
+            );
+
+            RankedRun expectedRetrievedSecond = new()
+            {
+                Count = 0,
+                Rank = 0,
+                Run = second,
+            };
+
+            retrievedSecond.Should().BeEquivalentTo(RunViewModel.MapFrom(expectedRetrievedSecond));
         }
 
         [TestCase("1")]

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
@@ -123,13 +122,12 @@ namespace LeaderboardBackend.Test
             // Needed for resolving the run type for viewmodel mapping
             await context.Entry(pb).Reference(r => r.Category).LoadAsync();
             await context.Entry(pb).Reference(r => r.User).LoadAsync();
+            await context.Entry(pb.Category).Reference(c => c.Leaderboard).LoadAsync();
             await context.Entry(second).Reference(r => r.Category).LoadAsync();
             await context.Entry(second).Reference(r => r.User).LoadAsync();
+            await context.Entry(second.Category).Reference(c => c.Leaderboard).LoadAsync();
 
-            TimedRunViewModel retrievedPb = await _apiClient.Get<TimedRunViewModel>(
-                $"/api/runs/{pb.Id.ToUrlSafeBase64String()}",
-                new() { }
-            );
+            HttpResponseMessage retrievedPb = await _apiClient.GetRun(pb.Id);
 
             RankedRun expectedRetrievedPb = new()
             {
@@ -138,12 +136,12 @@ namespace LeaderboardBackend.Test
                 Run = pb,
             };
 
-            retrievedPb.Should().BeEquivalentTo(RunViewModel.MapFrom(expectedRetrievedPb));
+            retrievedPb.Should().Be200Ok().And.Satisfy<TimedRunViewModelFull>(rankedRun =>
+            {
+                rankedRun.Should().BeEquivalentTo(RunViewModelFull.MapFrom(expectedRetrievedPb));
+            });
 
-            TimedRunViewModel retrievedSecond = await _apiClient.Get<TimedRunViewModel>(
-                $"/api/runs/{second.Id.ToUrlSafeBase64String()}",
-                new() { }
-            );
+            HttpResponseMessage retrievedSecond = await _apiClient.GetRun(second.Id);
 
             RankedRun expectedRetrievedSecond = new()
             {
@@ -152,7 +150,10 @@ namespace LeaderboardBackend.Test
                 Run = second,
             };
 
-            retrievedSecond.Should().BeEquivalentTo(RunViewModel.MapFrom(expectedRetrievedSecond));
+            retrievedSecond.Should().Be200Ok().And.Satisfy<TimedRunViewModelFull>(rankedRun =>
+            {
+                rankedRun.Should().BeEquivalentTo(RunViewModelFull.MapFrom(expectedRetrievedSecond));
+            });
         }
 
         [TestCase("1")]
@@ -461,7 +462,8 @@ namespace LeaderboardBackend.Test
                 DeletedAt = null,
                 Id = created.Id,
                 Status = Status.Published,
-                UpdatedAt = null
+                UpdatedAt = null,
+                Rank = 1
             });
         }
 

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -24,7 +24,7 @@ public class RunsController(
     [SwaggerResponse(404, "The Run with ID `id` could not be found.", typeof(ProblemDetails))]
     public async Task<ActionResult<RunViewModel>> GetRun([FromRoute] Guid id)
     {
-        Run? run = await runService.GetRun(id);
+        RankedRun? run = await runService.GetRun(id);
 
         if (run is null)
         {
@@ -165,14 +165,14 @@ public class RunsController(
     [SwaggerResponse(404)]
     public async Task<ActionResult<CategoryViewModel>> GetCategoryForRun(Guid id)
     {
-        Run? run = await runService.GetRun(id);
+        RankedRun? run = await runService.GetRun(id);
 
         if (run is null)
         {
             return NotFound("Run Not Found");
         }
 
-        Category? category = await categoryService.GetCategoryForRun(run);
+        Category? category = await categoryService.GetCategoryForRun(run.Run);
 
         if (category is null)
         {

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -84,7 +84,7 @@ public class RunsController(
             {
                 CreatedAtActionResult result = CreatedAtAction(
                     nameof(GetRun),
-                    new { id = run.Id.ToUrlSafeBase64String() },
+                    new { id = run.Run.Id.ToUrlSafeBase64String() },
                     RunViewModel.MapFrom(run)
                 );
                 return result;

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -94,7 +94,7 @@ public class RunsController(
             {
                 CreatedAtActionResult result = CreatedAtAction(
                     nameof(GetRun),
-                    new { id = run.Id.ToUrlSafeBase64String() },
+                    new { id = run.Run.Id.ToUrlSafeBase64String() },
                     RunViewModel.MapFrom(run)
                 );
                 return result;

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -24,7 +24,7 @@ public class RunsController(
     [SwaggerResponse(404, "The Run with ID `id` could not be found.", typeof(ProblemDetails))]
     public async Task<ActionResult<RunViewModelFull>> GetRun([FromRoute] Guid id)
     {
-        Run? run = await runService.GetRun(id);
+        RankedRun? run = await runService.GetRun(id);
 
         if (run is null)
         {
@@ -175,14 +175,14 @@ public class RunsController(
     [SwaggerResponse(404, Type = typeof(ProblemDetails))]
     public async Task<ActionResult<CategoryViewModel>> GetCategoryForRun(Guid id)
     {
-        Run? run = await runService.GetRun(id);
+        RankedRun? run = await runService.GetRun(id);
 
         if (run is null)
         {
             return NotFound("Run Not Found");
         }
 
-        Category? category = await categoryService.GetCategoryForRun(run);
+        Category? category = await categoryService.GetCategoryForRun(run.Run);
 
         if (category is null)
         {

--- a/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
@@ -158,6 +158,13 @@ public record RunViewModelFull : RunViewModel
         },
         _ => throw new NotImplementedException(),
     };
+
+    public static new RunViewModelFull MapFrom(RankedRun ranked)
+    {
+        RunViewModelFull viewModel = MapFrom(ranked.Run);
+        viewModel.Rank = ranked.Rank;
+        return viewModel;
+    }
 }
 
 /// <summary>

--- a/LeaderboardBackend/Services/IRunService.cs
+++ b/LeaderboardBackend/Services/IRunService.cs
@@ -8,7 +8,10 @@ namespace LeaderboardBackend.Services;
 
 public interface IRunService
 {
-    Task<Run?> GetRun(Guid id);
+    /// <summary>
+    /// Includes the rank of the fetched run if it's the user's personal best.
+    /// </summary>
+    Task<RankedRun?> GetRun(Guid id);
     Task<GetRunsForCategoryResult> GetRunsForCategory(long id, StatusFilter statusFilter, Page page);
     /// <summary>
     /// Returns the top-scoring runs of every unique User for a category.

--- a/LeaderboardBackend/Services/IRunService.cs
+++ b/LeaderboardBackend/Services/IRunService.cs
@@ -54,7 +54,7 @@ public interface IRunService
 }
 
 [GenerateOneOf]
-public partial class CreateRunResult : OneOfBase<Run, BadRole, BadRunType>;
+public partial class CreateRunResult : OneOfBase<RankedRun, BadRole, BadRunType>;
 
 [GenerateOneOf]
 public partial class UpdateRunResult : OneOfBase<BadRole, UserDoesNotOwnRun, UserCannotChangeStatusOfRuns, NotFound, AlreadyDeleted, BadRunType, Success>;

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -11,11 +11,34 @@ namespace LeaderboardBackend.Services;
 
 public class RunService(ApplicationContext applicationContext, IClock clock) : IRunService
 {
-    public async Task<Run?> GetRun(Guid id) =>
-        await applicationContext.Runs
+    public async Task<RankedRun?> GetRun(Guid id) {
+        Run? unranked = await applicationContext.Runs
             .Include(run => run.Category)
             .Include(run => run.User)
             .SingleOrDefaultAsync(run => run.Id == id);
+
+        if (unranked == null)
+        {
+            return null;
+        }
+
+        IQueryable<RankedRun> query = GetPersonalBests(unranked.Category);
+
+        RankedRun pb = await query.Where(r => r.Run.UserId == unranked.UserId)
+            .FirstAsync();
+
+        if (pb.Run.Id == unranked.Id)
+        {
+            return pb;
+        }
+
+        return new RankedRun
+        {
+            Count = pb.Count,
+            Rank = 0,
+            Run = unranked
+        };
+    }
 
     public async Task<GetRunsForCategoryResult> GetRunsForCategory(
         long id,
@@ -73,27 +96,7 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
         // Query the best run from each user.
 
-        IQueryable<RankedRun> query = applicationContext.Runs
-            .Include(r => r.Category)
-            .Include(r => r.User)
-            .Where(r => r.CategoryId == id && r.DeletedAt == null)
-            .Where(r => EF.Functions.RowNumber((
-                asc ?
-                EF.Functions.Over().PartitionBy(r.UserId).OrderBy(r.TimeOrScore) :
-                EF.Functions.Over().PartitionBy(r.UserId).OrderByDescending(r.TimeOrScore)
-            ).ThenBy(r.PlayedOn).ThenBy(r.CreatedAt)) == 1L)
-
-        // Assign each run a rank relative to the other users' best runs and count them up.
-
-            .Select(r => new RankedRun
-            {
-                Rank = EF.Functions.Rank(
-                    asc ?
-                    EF.Functions.Over().OrderBy(r.TimeOrScore) :
-                    EF.Functions.Over().OrderByDescending(r.TimeOrScore)),
-                Run = r,
-                Count = EF.Functions.Count<long>(EF.Functions.Over())
-            });
+        IQueryable<RankedRun> query = GetPersonalBests(cat);
 
         // Break ties and apply pagination.
 
@@ -310,5 +313,34 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
         run.DeletedAt = clock.GetCurrentInstant();
         await applicationContext.SaveChangesAsync();
         return new Success();
+    }
+
+    private IQueryable<RankedRun> GetPersonalBests (Category cat)
+    {
+        bool asc = cat.SortDirection == SortDirection.Ascending;
+
+        // Query the best run from each user.
+
+        return applicationContext.Runs
+            .Include(r => r.Category)
+            .Include(r => r.User)
+            .Where(r => r.CategoryId == cat.Id && r.DeletedAt == null)
+            .Where(r => EF.Functions.RowNumber((
+                asc ?
+                EF.Functions.Over().PartitionBy(r.UserId).OrderBy(r.TimeOrScore) :
+                EF.Functions.Over().PartitionBy(r.UserId).OrderByDescending(r.TimeOrScore)
+            ).ThenBy(r.PlayedOn).ThenBy(r.CreatedAt)) == 1L)
+
+        // Assign each run a rank relative to the other users' best runs and count them up.
+
+            .Select(r => new RankedRun
+            {
+                Rank = EF.Functions.Rank(
+                    asc ?
+                    EF.Functions.Over().OrderBy(r.TimeOrScore) :
+                    EF.Functions.Over().OrderByDescending(r.TimeOrScore)),
+                Run = r,
+                Count = EF.Functions.Count<long>(EF.Functions.Over())
+            });
     }
 }

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -177,7 +177,20 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
         applicationContext.Add(run);
         await applicationContext.SaveChangesAsync();
-        return run;
+
+        RankedRun pb = await GetPersonalBests(category).Where(r => r.Run.UserId == user.Id).FirstAsync();
+
+        if (pb.Run.Id == run.Id)
+        {
+            return pb;
+        }
+
+        return new RankedRun
+        {
+            Count = 0,
+            Rank = 0,
+            Run = run
+        };
     }
 
     public async Task<UpdateRunResult> UpdateRun(User user, Guid id, UpdateRunRequest request)
@@ -316,7 +329,7 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
         return new Success();
     }
 
-    private IQueryable<RankedRun> GetPersonalBests (Category cat)
+    private IQueryable<RankedRun> GetPersonalBests(Category cat)
     {
         bool asc = cat.SortDirection == SortDirection.Ascending;
 

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -11,7 +11,8 @@ namespace LeaderboardBackend.Services;
 
 public class RunService(ApplicationContext applicationContext, IClock clock) : IRunService
 {
-    public async Task<RankedRun?> GetRun(Guid id) {
+    public async Task<RankedRun?> GetRun(Guid id)
+    {
         Run? unranked = await applicationContext.Runs
             .Include(run => run.Category)
             .Include(run => run.User)
@@ -34,7 +35,7 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
         return new RankedRun
         {
-            Count = pb.Count,
+            Count = 0,
             Rank = 0,
             Run = unranked
         };

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -36,7 +36,7 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
         return new RankedRun
         {
-            Count = pb.Count,
+            Count = 0,
             Rank = 0,
             Run = unranked
         };

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -11,12 +11,36 @@ namespace LeaderboardBackend.Services;
 
 public class RunService(ApplicationContext applicationContext, IClock clock) : IRunService
 {
-    public Task<Run?> GetRun(Guid id) =>
-        applicationContext.Runs
+    public async Task<RankedRun?> GetRun(Guid id)
+    {
+        Run? unranked = await applicationContext.Runs
             .Include(run => run.Category)
             .ThenInclude(cat => cat.Leaderboard)
             .Include(run => run.User)
             .SingleOrDefaultAsync(run => run.Id == id);
+
+        if (unranked == null)
+        {
+            return null;
+        }
+
+        IQueryable<RankedRun> query = GetPersonalBests(unranked.Category);
+
+        RankedRun pb = await query.Where(r => r.Run.UserId == unranked.UserId)
+            .FirstAsync();
+
+        if (pb.Run.Id == unranked.Id)
+        {
+            return pb;
+        }
+
+        return new RankedRun
+        {
+            Count = pb.Count,
+            Rank = 0,
+            Run = unranked
+        };
+    }
 
     public async Task<GetRunsForCategoryResult> GetRunsForCategory(
         long id,
@@ -74,27 +98,7 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
         // Query the best run from each user.
 
-        IQueryable<RankedRun> query = applicationContext.Runs
-            .Include(r => r.Category)
-            .Include(r => r.User)
-            .Where(r => r.CategoryId == id && r.DeletedAt == null)
-            .Where(r => EF.Functions.RowNumber((
-                asc ?
-                EF.Functions.Over().PartitionBy(r.UserId).OrderBy(r.TimeOrScore) :
-                EF.Functions.Over().PartitionBy(r.UserId).OrderByDescending(r.TimeOrScore)
-            ).ThenBy(r.PlayedOn).ThenBy(r.CreatedAt)) == 1L)
-
-        // Assign each run a rank relative to the other users' best runs and count them up.
-
-            .Select(r => new RankedRun
-            {
-                Rank = EF.Functions.Rank(
-                    asc ?
-                    EF.Functions.Over().OrderBy(r.TimeOrScore) :
-                    EF.Functions.Over().OrderByDescending(r.TimeOrScore)),
-                Run = r,
-                Count = EF.Functions.Count<long>(EF.Functions.Over())
-            });
+        IQueryable<RankedRun> query = GetPersonalBests(cat);
 
         // Break ties and apply pagination.
 
@@ -311,5 +315,34 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
         run.DeletedAt = clock.GetCurrentInstant();
         await applicationContext.SaveChangesAsync();
         return new Success();
+    }
+
+    private IQueryable<RankedRun> GetPersonalBests(Category cat)
+    {
+        bool asc = cat.SortDirection == SortDirection.Ascending;
+
+        // Query the best run from each user.
+
+        return applicationContext.Runs
+            .Include(r => r.Category)
+            .Include(r => r.User)
+            .Where(r => r.CategoryId == cat.Id && r.DeletedAt == null)
+            .Where(r => EF.Functions.RowNumber((
+                asc ?
+                EF.Functions.Over().PartitionBy(r.UserId).OrderBy(r.TimeOrScore) :
+                EF.Functions.Over().PartitionBy(r.UserId).OrderByDescending(r.TimeOrScore)
+            ).ThenBy(r.PlayedOn).ThenBy(r.CreatedAt)) == 1L)
+
+        // Assign each run a rank relative to the other users' best runs and count them up.
+
+            .Select(r => new RankedRun
+            {
+                Rank = EF.Functions.Rank(
+                    asc ?
+                    EF.Functions.Over().OrderBy(r.TimeOrScore) :
+                    EF.Functions.Over().OrderByDescending(r.TimeOrScore)),
+                Run = r,
+                Count = EF.Functions.Count<long>(EF.Functions.Over())
+            });
     }
 }

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -178,7 +178,20 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
         applicationContext.Add(run);
         await applicationContext.SaveChangesAsync();
-        return run;
+
+        RankedRun pb = await GetPersonalBests(category).Where(r => r.Run.UserId == user.Id).FirstAsync();
+
+        if (pb.Run.Id == run.Id)
+        {
+            return pb;
+        }
+
+        return new RankedRun
+        {
+            Count = 0,
+            Rank = 0,
+            Run = run
+        };
     }
 
     public async Task<UpdateRunResult> UpdateRun(User user, Guid id, UpdateRunRequest request)


### PR DESCRIPTION
Given these two runs by the same user, ordered best-first:
<img width="1258" height="93" alt="image" src="https://github.com/user-attachments/assets/436b78a8-97d2-4a6d-9093-85c51ab19cba" />

Fetching the better-performing run (`rank` is included):
<img width="607" height="593" alt="image" src="https://github.com/user-attachments/assets/5261dba5-3c6a-4e4d-ab82-44e0da34ed79" />

Fetching the worse-performing run:
<img width="531" height="595" alt="image" src="https://github.com/user-attachments/assets/a78f344e-d3cb-458d-bb29-c1c6abd9aefb" />
