### PR TITLE
Return Relations in GetRun

### DIFF
--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -422,7 +422,7 @@ namespace LeaderboardBackend.Test
                 Time = Duration.FromTimeSpan(new(0, 0, 10, 22, 111)),
                 User = UserViewModel.MapFrom(user),
                 CategoryId = _categoryIds[0],
-                Category = CategoryViewModel.MapFrom(category!),
+                Category = CategoryViewModelWithRelations.MapFrom(category!),
                 CreatedAt = _clock.GetCurrentInstant(),
                 DeletedAt = null,
                 Id = created.Id,

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -415,14 +415,14 @@ namespace LeaderboardBackend.Test
 
             Category? category = await context.Categories.Include(c => c.Leaderboard).SingleAsync(c => c.Id == _categoryIds[0]);
 
-            response3.Should().Be200Ok().And.BeAs(created).And.BeAs(new TimedRunViewModelWithRelations()
+            response3.Should().Be200Ok().And.BeAs(created).And.BeAs(new TimedRunViewModelFull()
             {
                 PlayedOn = new(2025, 1, 1),
                 Info = "",
                 Time = Duration.FromTimeSpan(new(0, 0, 10, 22, 111)),
                 User = UserViewModel.MapFrom(user),
                 CategoryId = _categoryIds[0],
-                Category = CategoryViewModelWithRelations.MapFrom(category!),
+                Category = CategoryViewModelFull.MapFrom(category!),
                 CreatedAt = _clock.GetCurrentInstant(),
                 DeletedAt = null,
                 Id = created.Id,

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -413,13 +413,15 @@ namespace LeaderboardBackend.Test
 
             HttpResponseMessage response3 = await _apiClient.GetRun(created!.Id);
 
+            Category? category = await context.Categories.Include(c => c.Leaderboard).SingleAsync(c => c.Id == _categoryIds[0]);
+
             response3.Should().Be200Ok().And.BeAs(created).And.BeAs(new TimedRunViewModel()
             {
                 PlayedOn = new(2025, 1, 1),
                 Info = "",
                 Time = Duration.FromTimeSpan(new(0, 0, 10, 22, 111)),
                 User = UserViewModel.MapFrom(user),
-                CategoryId = _categoryIds[0],
+                Category = CategoryViewModel.MapFrom(category!),
                 CreatedAt = _clock.GetCurrentInstant(),
                 DeletedAt = null,
                 Id = created.Id,

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -415,12 +415,13 @@ namespace LeaderboardBackend.Test
 
             Category? category = await context.Categories.Include(c => c.Leaderboard).SingleAsync(c => c.Id == _categoryIds[0]);
 
-            response3.Should().Be200Ok().And.BeAs(created).And.BeAs(new TimedRunViewModel()
+            response3.Should().Be200Ok().And.BeAs(created).And.BeAs(new TimedRunViewModelWithRelations()
             {
                 PlayedOn = new(2025, 1, 1),
                 Info = "",
                 Time = Duration.FromTimeSpan(new(0, 0, 10, 22, 111)),
                 User = UserViewModel.MapFrom(user),
+                CategoryId = _categoryIds[0],
                 Category = CategoryViewModel.MapFrom(category!),
                 CreatedAt = _clock.GetCurrentInstant(),
                 DeletedAt = null,

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -22,7 +22,7 @@ public class RunsController(
     [SwaggerOperation("Gets a Run by its ID.", OperationId = "getRun")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404, "The Run with ID `id` could not be found.", typeof(ProblemDetails))]
-    public async Task<ActionResult<RunViewModel>> GetRun([FromRoute] Guid id)
+    public async Task<ActionResult<RunViewModelWithRelations>> GetRun([FromRoute] Guid id)
     {
         Run? run = await runService.GetRun(id);
 
@@ -31,7 +31,7 @@ public class RunsController(
             return NotFound();
         }
 
-        return Ok(RunViewModel.MapFrom(run));
+        return Ok(RunViewModelWithRelations.MapFrom(run));
     }
 
     [Authorize]

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -22,7 +22,7 @@ public class RunsController(
     [SwaggerOperation("Gets a Run by its ID.", OperationId = "getRun")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404, "The Run with ID `id` could not be found.", typeof(ProblemDetails))]
-    public async Task<ActionResult<RunViewModelWithRelations>> GetRun([FromRoute] Guid id)
+    public async Task<ActionResult<RunViewModelFull>> GetRun([FromRoute] Guid id)
     {
         Run? run = await runService.GetRun(id);
 
@@ -31,7 +31,7 @@ public class RunsController(
             return NotFound();
         }
 
-        return Ok(RunViewModelWithRelations.MapFrom(run));
+        return Ok(RunViewModelFull.MapFrom(run));
     }
 
     [Authorize]

--- a/LeaderboardBackend/Models/Entities/Run.cs
+++ b/LeaderboardBackend/Models/Entities/Run.cs
@@ -56,7 +56,7 @@ public class Run : IHasUpdateTimestamp, IHasDeletionTimestamp
     public Instant? DeletedAt { get; set; }
 
     /// <summary>
-    /// 	The ID of the `Category` for `Run`.
+    /// 	The ID of the `Category` for the `Run`.
     /// </summary>
     public long CategoryId { get; set; }
 

--- a/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
@@ -65,7 +65,7 @@ public record CategoryViewModel
         SortDirection = category.SortDirection,
         Type = category.Type,
         LeaderboardId = category.LeaderboardId,
-        Leaderboard = category.Leaderboard != null ? LeaderboardViewModel.MapFrom(category.Leaderboard) : null,
+        Leaderboard = LeaderboardViewModel.MapFrom(category.Leaderboard!),
         CreatedAt = category.CreatedAt,
         UpdatedAt = category.UpdatedAt,
         DeletedAt = category.DeletedAt,

--- a/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
@@ -41,10 +41,6 @@ public record CategoryViewModel
     /// <inheritdoc cref="Category.LeaderboardId" />
     public required long LeaderboardId { get; set; }
 
-    /// <inheritdoc cref="Category.Leaderboard" />
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public required LeaderboardViewModel? Leaderboard { get; set; }
-
     /// <inheritdoc cref="Category.CreatedAt" />
     public required Instant CreatedAt { get; set; }
 
@@ -57,6 +53,27 @@ public record CategoryViewModel
     public required Status Status { get; set; }
 
     public static CategoryViewModel MapFrom(Category category) => new()
+    {
+        Id = category.Id,
+        Name = category.Name,
+        Slug = category.Slug,
+        Info = category.Info,
+        SortDirection = category.SortDirection,
+        Type = category.Type,
+        LeaderboardId = category.LeaderboardId,
+        CreatedAt = category.CreatedAt,
+        UpdatedAt = category.UpdatedAt,
+        DeletedAt = category.DeletedAt,
+        Status = category.Status()
+    };
+}
+
+public record CategoryViewModelWithRelations : CategoryViewModel
+{
+    /// <inheritdoc cref="Category.Leaderboard" />
+    public LeaderboardViewModel Leaderboard { get; set; } = null!;
+
+    public static new CategoryViewModelWithRelations MapFrom(Category category) => new()
     {
         Id = category.Id,
         Name = category.Name,

--- a/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
@@ -68,12 +68,15 @@ public record CategoryViewModel
     };
 }
 
-public record CategoryViewModelWithRelations : CategoryViewModel
+/// <summary>
+/// A <see cref="CategoryViewModel"/> with relations attached.
+/// </summary>
+public record CategoryViewModelFull : CategoryViewModel
 {
     /// <inheritdoc cref="Category.Leaderboard" />
-    public LeaderboardViewModel Leaderboard { get; set; } = null!;
+    public required LeaderboardViewModel Leaderboard { get; set; }
 
-    public static new CategoryViewModelWithRelations MapFrom(Category category) => new()
+    public static new CategoryViewModelFull MapFrom(Category category) => new()
     {
         Id = category.Id,
         Name = category.Name,

--- a/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using LeaderboardBackend.Models.Entities;
 using NodaTime;
 
@@ -40,6 +41,10 @@ public record CategoryViewModel
     /// <inheritdoc cref="Category.LeaderboardId" />
     public required long LeaderboardId { get; set; }
 
+    /// <inheritdoc cref="Category.Leaderboard" />
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required LeaderboardViewModel? Leaderboard { get; set; }
+
     /// <inheritdoc cref="Category.CreatedAt" />
     public required Instant CreatedAt { get; set; }
 
@@ -60,6 +65,7 @@ public record CategoryViewModel
         SortDirection = category.SortDirection,
         Type = category.Type,
         LeaderboardId = category.LeaderboardId,
+        Leaderboard = category.Leaderboard != null ? LeaderboardViewModel.MapFrom(category.Leaderboard) : null,
         CreatedAt = category.CreatedAt,
         UpdatedAt = category.UpdatedAt,
         DeletedAt = category.DeletedAt,

--- a/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
@@ -43,9 +43,9 @@ public abstract record RunViewModel
     public required Instant? DeletedAt { get; set; }
 
     /// <summary>
-    /// 	The ID of the `Category` for `Run`.
+    /// 	The `Category` for the `Run`.
     /// </summary>
-    public required long CategoryId { get; set; }
+    public required CategoryViewModel Category { get; set; }
 
     /// <summary>
     ///     The user who submitted this run.
@@ -65,7 +65,7 @@ public abstract record RunViewModel
         RunType.Time => new TimedRunViewModel
         {
             Id = run.Id,
-            CategoryId = run.CategoryId,
+            Category = CategoryViewModel.MapFrom(run.Category),
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,
@@ -78,7 +78,7 @@ public abstract record RunViewModel
         RunType.Score => new ScoredRunViewModel
         {
             Id = run.Id,
-            CategoryId = run.CategoryId,
+            Category = CategoryViewModel.MapFrom(run.Category),
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,

--- a/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
@@ -43,9 +43,9 @@ public abstract record RunViewModel
     public required Instant? DeletedAt { get; set; }
 
     /// <summary>
-    /// 	The `Category` for the `Run`.
+    /// 	The ID of the `Category` for `Run`.
     /// </summary>
-    public required CategoryViewModel Category { get; set; }
+    public required long CategoryId { get; set; }
 
     /// <summary>
     ///     The user who submitted this run.
@@ -65,7 +65,7 @@ public abstract record RunViewModel
         RunType.Time => new TimedRunViewModel
         {
             Id = run.Id,
-            Category = CategoryViewModel.MapFrom(run.Category),
+            CategoryId = run.CategoryId,
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,
@@ -78,7 +78,7 @@ public abstract record RunViewModel
         RunType.Score => new ScoredRunViewModel
         {
             Id = run.Id,
-            Category = CategoryViewModel.MapFrom(run.Category),
+            CategoryId = run.CategoryId,
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,
@@ -112,5 +112,58 @@ public record ScoredRunViewModel : RunViewModel
     /// <summary>
     ///     The score achieved during the run.
     /// </summary>
+    public required long Score { get; set; }
+}
+
+[JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor)]
+[JsonDerivedType(typeof(TimedRunViewModelWithRelations), "Time")]
+[JsonDerivedType(typeof(ScoredRunViewModelWithRelations), "Score")]
+public record RunViewModelWithRelations : RunViewModel
+{
+    public CategoryViewModel Category { get; set; } = null!;
+
+    public static new RunViewModelWithRelations MapFrom(Run run) => run.Type switch
+    {
+        RunType.Time => new TimedRunViewModelWithRelations
+        {
+            Id = run.Id,
+            CategoryId = run.CategoryId,
+            Category = CategoryViewModel.MapFrom(run.Category),
+            User = UserViewModel.MapFrom(run.User),
+            PlayedOn = run.PlayedOn,
+            CreatedAt = run.CreatedAt,
+            UpdatedAt = run.UpdatedAt,
+            DeletedAt = run.DeletedAt,
+            Info = run.Info,
+            Time = run.Time,
+            Status = run.Status()
+        },
+        RunType.Score => new ScoredRunViewModelWithRelations
+        {
+            Id = run.Id,
+            CategoryId = run.CategoryId,
+            Category = CategoryViewModel.MapFrom(run.Category),
+            User = UserViewModel.MapFrom(run.User),
+            PlayedOn = run.PlayedOn,
+            CreatedAt = run.CreatedAt,
+            UpdatedAt = run.UpdatedAt,
+            DeletedAt = run.DeletedAt,
+            Info = run.Info,
+            Score = run.TimeOrScore,
+            Status = run.Status()
+        },
+        _ => throw new NotImplementedException(),
+    };
+}
+
+public record TimedRunViewModelWithRelations : RunViewModelWithRelations
+{
+    /// <inheritdoc cref="TimedRunViewModel.Time" />
+    public required Duration Time { get; set; }
+}
+
+public record ScoredRunViewModelWithRelations : RunViewModelWithRelations
+{
+    /// <inheritdoc cref="ScoredRunViewModel.Score" />
     public required long Score { get; set; }
 }

--- a/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
@@ -115,20 +115,24 @@ public record ScoredRunViewModel : RunViewModel
     public required long Score { get; set; }
 }
 
-[JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor)]
-[JsonDerivedType(typeof(TimedRunViewModelWithRelations), "Time")]
-[JsonDerivedType(typeof(ScoredRunViewModelWithRelations), "Score")]
-public record RunViewModelWithRelations : RunViewModel
-{
-    public CategoryViewModelWithRelations Category { get; set; } = null!;
+/// <summary>
+/// A <see cref="RunViewModel"/> with relations attached.
+/// </summary>
 
-    public static new RunViewModelWithRelations MapFrom(Run run) => run.Type switch
+[JsonPolymorphic(UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor)]
+[JsonDerivedType(typeof(TimedRunViewModelFull), "Time")]
+[JsonDerivedType(typeof(ScoredRunViewModelFull), "Score")]
+public record RunViewModelFull : RunViewModel
+{
+    public required CategoryViewModelFull Category { get; set; }
+
+    public static new RunViewModelFull MapFrom(Run run) => run.Type switch
     {
-        RunType.Time => new TimedRunViewModelWithRelations
+        RunType.Time => new TimedRunViewModelFull
         {
             Id = run.Id,
             CategoryId = run.CategoryId,
-            Category = CategoryViewModelWithRelations.MapFrom(run.Category),
+            Category = CategoryViewModelFull.MapFrom(run.Category),
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,
@@ -138,11 +142,11 @@ public record RunViewModelWithRelations : RunViewModel
             Time = run.Time,
             Status = run.Status()
         },
-        RunType.Score => new ScoredRunViewModelWithRelations
+        RunType.Score => new ScoredRunViewModelFull
         {
             Id = run.Id,
             CategoryId = run.CategoryId,
-            Category = CategoryViewModelWithRelations.MapFrom(run.Category),
+            Category = CategoryViewModelFull.MapFrom(run.Category),
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,
@@ -156,13 +160,19 @@ public record RunViewModelWithRelations : RunViewModel
     };
 }
 
-public record TimedRunViewModelWithRelations : RunViewModelWithRelations
+/// <summary>
+/// A <see cref="TimedRunViewModel"/> with relations attached.
+/// </summary>
+public record TimedRunViewModelFull : RunViewModelFull
 {
     /// <inheritdoc cref="TimedRunViewModel.Time" />
     public required Duration Time { get; set; }
 }
 
-public record ScoredRunViewModelWithRelations : RunViewModelWithRelations
+/// <summary>
+/// A <see cref="ScoredRunViewModel"/> with relations attached.
+/// </summary>
+public record ScoredRunViewModelFull : RunViewModelFull
 {
     /// <inheritdoc cref="ScoredRunViewModel.Score" />
     public required long Score { get; set; }

--- a/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
@@ -120,7 +120,7 @@ public record ScoredRunViewModel : RunViewModel
 [JsonDerivedType(typeof(ScoredRunViewModelWithRelations), "Score")]
 public record RunViewModelWithRelations : RunViewModel
 {
-    public CategoryViewModel Category { get; set; } = null!;
+    public CategoryViewModelWithRelations Category { get; set; } = null!;
 
     public static new RunViewModelWithRelations MapFrom(Run run) => run.Type switch
     {
@@ -128,7 +128,7 @@ public record RunViewModelWithRelations : RunViewModel
         {
             Id = run.Id,
             CategoryId = run.CategoryId,
-            Category = CategoryViewModel.MapFrom(run.Category),
+            Category = CategoryViewModelWithRelations.MapFrom(run.Category),
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,
@@ -142,7 +142,7 @@ public record RunViewModelWithRelations : RunViewModel
         {
             Id = run.Id,
             CategoryId = run.CategoryId,
-            Category = CategoryViewModel.MapFrom(run.Category),
+            Category = CategoryViewModelWithRelations.MapFrom(run.Category),
             User = UserViewModel.MapFrom(run.User),
             PlayedOn = run.PlayedOn,
             CreatedAt = run.CreatedAt,

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -14,6 +14,7 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
     public Task<Run?> GetRun(Guid id) =>
         applicationContext.Runs
             .Include(run => run.Category)
+            .ThenInclude(cat => cat.Leaderboard)
             .Include(run => run.User)
             .SingleOrDefaultAsync(run => run.Id == id);
 

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -1198,15 +1198,16 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/RunViewModelWithRelations"
+                      "$ref": "#/components/schemas/RunViewModelFull"
                     },
                     {
-                      "$ref": "#/components/schemas/TimedRunViewModelWithRelations"
+                      "$ref": "#/components/schemas/TimedRunViewModelFull"
                     },
                     {
-                      "$ref": "#/components/schemas/ScoredRunViewModelWithRelations"
+                      "$ref": "#/components/schemas/ScoredRunViewModelFull"
                     }
-                  ]
+                  ],
+                  "description": "A LeaderboardBackend.Models.ViewModels.RunViewModel with relations attached."
                 }
               }
             }
@@ -2008,45 +2009,13 @@
         },
         "additionalProperties": { }
       },
-      "CategoryViewModelListView": {
-        "required": [
-          "data",
-          "limitDefault",
-          "limitMax",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CategoryViewModel"
-            }
-          },
-          "total": {
-            "type": "integer",
-            "description": "The total number of records matching the given criteria that\nexist in the database, NOT the total number of records returned.",
-            "format": "int64"
-          },
-          "limitDefault": {
-            "type": "integer",
-            "description": "The default limit that will be applied for this resource type\nif the client does not specify one in the query string.",
-            "format": "int32"
-          },
-          "limitMax": {
-            "type": "integer",
-            "description": "The maximum value the client is allowed to specify as a limt for\nendpoints return a paginated list of resources of this type.\nExceeding this value will result in an error.",
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false
-      },
-      "CategoryViewModelWithRelations": {
+      "CategoryViewModelFull": {
         "required": [
           "createdAt",
           "deletedAt",
           "id",
           "info",
+          "leaderboard",
           "leaderboardId",
           "name",
           "slug",
@@ -2127,6 +2096,40 @@
               }
             ],
             "description": "Represents a collection of `Leaderboard` entities."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A LeaderboardBackend.Models.ViewModels.CategoryViewModel with relations attached."
+      },
+      "CategoryViewModelListView": {
+        "required": [
+          "data",
+          "limitDefault",
+          "limitMax",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryViewModel"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "The total number of records matching the given criteria that\nexist in the database, NOT the total number of records returned.",
+            "format": "int64"
+          },
+          "limitDefault": {
+            "type": "integer",
+            "description": "The default limit that will be applied for this resource type\nif the client does not specify one in the query string.",
+            "format": "int32"
+          },
+          "limitMax": {
+            "type": "integer",
+            "description": "The maximum value the client is allowed to specify as a limt for\nendpoints return a paginated list of resources of this type.\nExceeding this value will result in an error.",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -2652,49 +2655,10 @@
           }
         }
       },
-      "RunViewModelListView": {
-        "required": [
-          "data",
-          "limitDefault",
-          "limitMax",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/TimedRunViewModel"
-                },
-                {
-                  "$ref": "#/components/schemas/ScoredRunViewModel"
-                }
-              ]
-            }
-          },
-          "total": {
-            "type": "integer",
-            "description": "The total number of records matching the given criteria that\nexist in the database, NOT the total number of records returned.",
-            "format": "int64"
-          },
-          "limitDefault": {
-            "type": "integer",
-            "description": "The default limit that will be applied for this resource type\nif the client does not specify one in the query string.",
-            "format": "int32"
-          },
-          "limitMax": {
-            "type": "integer",
-            "description": "The maximum value the client is allowed to specify as a limt for\nendpoints return a paginated list of resources of this type.\nExceeding this value will result in an error.",
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false
-      },
-      "RunViewModelWithRelations": {
+      "RunViewModelFull": {
         "required": [
           "$type",
+          "category",
           "categoryId",
           "createdAt",
           "deletedAt",
@@ -2774,19 +2738,61 @@
           "category": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CategoryViewModelWithRelations"
+                "$ref": "#/components/schemas/CategoryViewModelFull"
               }
-            ]
+            ],
+            "description": "A LeaderboardBackend.Models.ViewModels.CategoryViewModel with relations attached."
           }
         },
         "additionalProperties": false,
+        "description": "A LeaderboardBackend.Models.ViewModels.RunViewModel with relations attached.",
         "discriminator": {
           "propertyName": "$type",
           "mapping": {
-            "Time": "#/components/schemas/TimedRunViewModelWithRelations",
-            "Score": "#/components/schemas/ScoredRunViewModelWithRelations"
+            "Time": "#/components/schemas/TimedRunViewModelFull",
+            "Score": "#/components/schemas/ScoredRunViewModelFull"
           }
         }
+      },
+      "RunViewModelListView": {
+        "required": [
+          "data",
+          "limitDefault",
+          "limitMax",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TimedRunViewModel"
+                },
+                {
+                  "$ref": "#/components/schemas/ScoredRunViewModel"
+                }
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "The total number of records matching the given criteria that\nexist in the database, NOT the total number of records returned.",
+            "format": "int64"
+          },
+          "limitDefault": {
+            "type": "integer",
+            "description": "The default limit that will be applied for this resource type\nif the client does not specify one in the query string.",
+            "format": "int32"
+          },
+          "limitMax": {
+            "type": "integer",
+            "description": "The maximum value the client is allowed to specify as a limt for\nendpoints return a paginated list of resources of this type.\nExceeding this value will result in an error.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
       },
       "ScoredRunViewModel": {
         "allOf": [
@@ -2809,10 +2815,10 @@
           }
         ]
       },
-      "ScoredRunViewModelWithRelations": {
+      "ScoredRunViewModelFull": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/RunViewModelWithRelations"
+            "$ref": "#/components/schemas/RunViewModelFull"
           },
           {
             "required": [
@@ -2827,7 +2833,8 @@
             },
             "additionalProperties": false
           }
-        ]
+        ],
+        "description": "A LeaderboardBackend.Models.ViewModels.ScoredRunViewModel with relations attached."
       },
       "SortDirection": {
         "enum": [
@@ -2884,10 +2891,10 @@
           }
         ]
       },
-      "TimedRunViewModelWithRelations": {
+      "TimedRunViewModelFull": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/RunViewModelWithRelations"
+            "$ref": "#/components/schemas/RunViewModelFull"
           },
           {
             "required": [
@@ -2902,7 +2909,8 @@
             },
             "additionalProperties": false
           }
-        ]
+        ],
+        "description": "A LeaderboardBackend.Models.ViewModels.TimedRunViewModel with relations attached."
       },
       "UpdateCategoryRequest": {
         "type": "object",

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -1889,6 +1889,7 @@
           "deletedAt",
           "id",
           "info",
+          "leaderboard",
           "leaderboardId",
           "name",
           "slug",
@@ -1937,6 +1938,15 @@
           "leaderboardId": {
             "type": "integer",
             "format": "int64"
+          },
+          "leaderboard": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LeaderboardViewModel"
+              }
+            ],
+            "description": "Represents a collection of `Leaderboard` entities.",
+            "nullable": true
           },
           "createdAt": {
             "type": "string",
@@ -2473,7 +2483,7 @@
       "RunViewModel": {
         "required": [
           "$type",
-          "categoryId",
+          "category",
           "createdAt",
           "deletedAt",
           "id",
@@ -2524,10 +2534,13 @@
             "nullable": true,
             "example": "1984-01-01T00:00:00Z"
           },
-          "categoryId": {
-            "type": "integer",
-            "description": "The ID of the `Category` for `Run`.",
-            "format": "int64"
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CategoryViewModel"
+              }
+            ],
+            "description": "The `Category` for the `Run`."
           },
           "user": {
             "allOf": [

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -1892,7 +1892,6 @@
           "deletedAt",
           "id",
           "info",
-          "leaderboard",
           "leaderboardId",
           "name",
           "slug",
@@ -1941,15 +1940,6 @@
           "leaderboardId": {
             "type": "integer",
             "format": "int64"
-          },
-          "leaderboard": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LeaderboardViewModel"
-              }
-            ],
-            "description": "Represents a collection of `Leaderboard` entities.",
-            "nullable": true
           },
           "createdAt": {
             "type": "string",
@@ -2047,6 +2037,96 @@
             "type": "integer",
             "description": "The maximum value the client is allowed to specify as a limt for\nendpoints return a paginated list of resources of this type.\nExceeding this value will result in an error.",
             "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CategoryViewModelWithRelations": {
+        "required": [
+          "createdAt",
+          "deletedAt",
+          "id",
+          "info",
+          "leaderboardId",
+          "name",
+          "slug",
+          "sortDirection",
+          "status",
+          "type",
+          "updatedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The unique identifier of the `Category`.\n",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the `Category`.",
+            "example": "Foo Bar Baz%"
+          },
+          "slug": {
+            "type": "string",
+            "description": "The URL-scoped unique identifier of the `Category`.\n",
+            "example": "foo-bar-baz"
+          },
+          "info": {
+            "type": "string",
+            "description": "Information pertaining to the `Category`.",
+            "nullable": true,
+            "example": "Video proof is required."
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunType"
+              }
+            ]
+          },
+          "sortDirection": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SortDirection"
+              }
+            ]
+          },
+          "leaderboardId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "1984-01-01T00:00:00Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": "1984-01-01T00:00:00Z"
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": "1984-01-01T00:00:00Z"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ]
+          },
+          "leaderboard": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LeaderboardViewModel"
+              }
+            ],
+            "description": "Represents a collection of `Leaderboard` entities."
           }
         },
         "additionalProperties": false
@@ -2694,10 +2774,9 @@
           "category": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CategoryViewModel"
+                "$ref": "#/components/schemas/CategoryViewModelWithRelations"
               }
-            ],
-            "description": "Represents a `Category` tied to a `Leaderboard`."
+            ]
           }
         },
         "additionalProperties": false,

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -1198,10 +1198,13 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/TimedRunViewModel"
+                      "$ref": "#/components/schemas/RunViewModelWithRelations"
                     },
                     {
-                      "$ref": "#/components/schemas/ScoredRunViewModel"
+                      "$ref": "#/components/schemas/TimedRunViewModelWithRelations"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ScoredRunViewModelWithRelations"
                     }
                   ]
                 }
@@ -2483,7 +2486,7 @@
       "RunViewModel": {
         "required": [
           "$type",
-          "category",
+          "categoryId",
           "createdAt",
           "deletedAt",
           "id",
@@ -2534,13 +2537,10 @@
             "nullable": true,
             "example": "1984-01-01T00:00:00Z"
           },
-          "category": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/CategoryViewModel"
-              }
-            ],
-            "description": "The `Category` for the `Run`."
+          "categoryId": {
+            "type": "integer",
+            "description": "The ID of the `Category` for `Run`.",
+            "format": "int64"
           },
           "user": {
             "allOf": [
@@ -2612,6 +2612,103 @@
         },
         "additionalProperties": false
       },
+      "RunViewModelWithRelations": {
+        "required": [
+          "$type",
+          "categoryId",
+          "createdAt",
+          "deletedAt",
+          "id",
+          "info",
+          "playedOn",
+          "status",
+          "updatedAt",
+          "user"
+        ],
+        "type": "object",
+        "properties": {
+          "$type": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "^[a-zA-Z0-9-_]{22}$",
+            "type": "string",
+            "description": "The unique identifier of the `Run`.\n\nGenerated on creation."
+          },
+          "info": {
+            "type": "string",
+            "description": "User-provided details about the run.",
+            "nullable": true
+          },
+          "playedOn": {
+            "type": "string",
+            "description": "The date the run was done, *not* when it was submitted.",
+            "format": "date",
+            "example": "2000-01-01"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The time the run was submitted to the DB.",
+            "format": "date-time",
+            "example": "1984-01-01T00:00:00Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The last time the run was updated or null.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "1984-01-01T00:00:00Z"
+          },
+          "deletedAt": {
+            "type": "string",
+            "description": "The time at which the run was deleted, or null if the run has not been deleted.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "1984-01-01T00:00:00Z"
+          },
+          "categoryId": {
+            "type": "integer",
+            "description": "The ID of the `Category` for `Run`.",
+            "format": "int64"
+          },
+          "user": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserViewModel"
+              }
+            ],
+            "description": "The user who submitted this run."
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ]
+          },
+          "rank": {
+            "type": "integer",
+            "description": "The run's rank within its category.",
+            "format": "int64"
+          },
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CategoryViewModel"
+              }
+            ],
+            "description": "Represents a `Category` tied to a `Leaderboard`."
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "Time": "#/components/schemas/TimedRunViewModelWithRelations",
+            "Score": "#/components/schemas/ScoredRunViewModelWithRelations"
+          }
+        }
+      },
       "ScoredRunViewModel": {
         "allOf": [
           {
@@ -2626,6 +2723,26 @@
               "score": {
                 "type": "integer",
                 "description": "The score achieved during the run.",
+                "format": "int64"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ScoredRunViewModelWithRelations": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RunViewModelWithRelations"
+          },
+          {
+            "required": [
+              "score"
+            ],
+            "type": "object",
+            "properties": {
+              "score": {
+                "type": "integer",
                 "format": "int64"
               }
             },
@@ -2681,6 +2798,26 @@
               "time": {
                 "type": "string",
                 "description": "The duration of the run.",
+                "example": "25:01:01.001"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "TimedRunViewModelWithRelations": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RunViewModelWithRelations"
+          },
+          {
+            "required": [
+              "time"
+            ],
+            "type": "object",
+            "properties": {
+              "time": {
+                "type": "string",
                 "example": "25:01:01.001"
               }
             },


### PR DESCRIPTION
Returns the (viewmodelled) relations in `GetRunForCategory`, instead of just their IDs.

Consequence of this is that both the board ID and the board viewmodel will be part of the response:

<img width="636" height="728" alt="image" src="https://github.com/user-attachments/assets/81b566e8-5c58-4fc2-a81a-c275507401b9" />

Also added a `JSONIgnore` on `CategoryViewModel.Leaderboard` to preserve existing behaviour on Category* endpoints, e.g. `GetCategoryBySlug` (notice the lack of `leaderboard` in the response):

<img width="568" height="512" alt="image" src="https://github.com/user-attachments/assets/5c9cd410-2fd1-47c5-a11c-5b1c474444f7" />
